### PR TITLE
Added additional ENV to facilitate emulator runtime arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This image contains the latest version of Android SDK with configured AVD.
 # Example
 
 ```bash
-docker run -it --device /dev/kvm -p 5554:5554 -p 5555:5555 thedrhax/android-avd
+docker run -it --device /dev/kvm -p 5554:5554 -p 5555:5555 --env ANDROID_EMULATOR_EXTRA_ARGS="-skin 480x800" thedrhax/android-avd
 ```
 
 The `--device /dev/kvm` flag is required to enable CPU hardware acceleration.

--- a/container/etc/supervisor/conf.d/supervisord.conf
+++ b/container/etc/supervisor/conf.d/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:emulator]
-command=/bin/bash -c "$ANDROID_HOME/tools/emulator -avd ${NAME} -no-window -no-audio"
+command=/bin/bash -c "$ANDROID_HOME/tools/emulator -avd ${NAME} -no-window -no-audio ${ANDROID_EMULATOR_EXTRA_ARGS}"
 stopsignal=KILL
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Thanks for the great Android container. It's slick and simple to use!

When using your system I hit a roadblock with testing under a range of resolutions.
This additional allows users to pass though extra command-line arguments to the emulator at startup.
I've included an example of use by modifying your README.md
Feel free to change the variable name or consider alternate solutions to this use case.